### PR TITLE
Feature: Add global SignalBus for cross-scene Lua/C++ events

### DIFF
--- a/Engine/Source/Engine/Engine.cpp
+++ b/Engine/Source/Engine/Engine.cpp
@@ -51,6 +51,7 @@
 #include "ScriptAutoReg.h"
 #include "ScriptFunc.h"
 #include "TimerManager.h"
+#include "SignalBus.h"
 #include "Nodes/Widgets/Button.h"
 #include "FileWatcher.h"
 #include "ScriptUtils.h"
@@ -914,6 +915,7 @@ void Shutdown()
 
     NetworkManager::Get()->Shutdown();
     SerialManager::Get()->Shutdown();
+    GetSignalBus()->Clear();
 
     for (uint32_t i = 0; i < sWorlds.size(); ++i)
     {

--- a/Engine/Source/Engine/Engine.h
+++ b/Engine/Source/Engine/Engine.h
@@ -24,6 +24,7 @@ void Quit();
 
 POLYPHASE_API class World* GetWorld(int32_t index);
 POLYPHASE_API int32_t GetNumWorlds();
+POLYPHASE_API class SignalBus* GetSignalBus();
 
 POLYPHASE_API struct EngineState* GetEngineState();
 POLYPHASE_API const struct EngineConfig* GetEngineConfig();

--- a/Engine/Source/Engine/SignalBus.cpp
+++ b/Engine/Source/Engine/SignalBus.cpp
@@ -1,0 +1,240 @@
+#include "SignalBus.h"
+
+#include "Nodes/Node.h"
+
+SignalBus gSignalBus;
+
+SignalBus* GetSignalBus()
+{
+    return &gSignalBus;
+}
+
+std::vector<Datum> SignalBusChannel::Emit(const std::vector<Datum>& args)
+{
+    std::vector<Datum> retVals;
+
+    mEmitting = true;
+
+    for (auto it = mConnectionMap.begin(); it != mConnectionMap.end();)
+    {
+        Node* node = it->first.Get<Node>();
+        if (node == nullptr)
+        {
+            it = mConnectionMap.erase(it);
+        }
+        else
+        {
+            Datum ret;
+            bool hasRet = false;
+
+            if (it->second.mFuncPointer != nullptr)
+            {
+                SignalBusHandlerFP handler = it->second.mFuncPointer;
+                ret = handler(node, args);
+                hasRet = ret.IsValid();
+            }
+            else if (it->second.mVoidFuncPointer != nullptr)
+            {
+                SignalBusHandlerVoidFP handler = it->second.mVoidFuncPointer;
+                handler(node, args);
+            }
+
+            if (it->second.mScriptFunc.IsValid())
+            {
+                std::vector<Datum> selfArgs;
+                selfArgs.reserve(args.size() + 1);
+                selfArgs.push_back(node);
+
+                if (args.size() > 0)
+                {
+                    selfArgs.insert(selfArgs.end(), args.begin(), args.end());
+                }
+
+                ret = it->second.mScriptFunc.CallR((uint32_t)selfArgs.size(), selfArgs.data());
+                hasRet = ret.IsValid();
+            }
+
+            if (hasRet)
+            {
+                retVals.push_back(ret);
+            }
+
+            ++it;
+        }
+    }
+
+    mEmitting = false;
+
+    for (uint32_t i = 0; i < mPendingDisconnects.size(); ++i)
+    {
+        mConnectionMap.erase(mPendingDisconnects[i]);
+    }
+    mPendingDisconnects.clear();
+
+    for (uint32_t i = 0; i < mPendingConnects.size(); ++i)
+    {
+        mConnectionMap[mPendingConnects[i].first] = mPendingConnects[i].second;
+    }
+    mPendingConnects.clear();
+
+    return retVals;
+}
+
+void SignalBusChannel::Connect(Node* node, SignalBusHandlerFP func)
+{
+    if (node != nullptr)
+    {
+        CleanupDeadConnections();
+        NodePtrWeak nodePtrWeak = ResolveWeakPtr(node);
+
+        SignalBusHandlerFunc handler;
+        handler.mFuncPointer = func;
+
+        if (mEmitting)
+        {
+            mPendingConnects.push_back({ nodePtrWeak, handler });
+        }
+        else
+        {
+            mConnectionMap[nodePtrWeak] = handler;
+        }
+    }
+}
+
+void SignalBusChannel::Connect(Node* node, SignalBusHandlerVoidFP func)
+{
+    if (node != nullptr)
+    {
+        CleanupDeadConnections();
+        NodePtrWeak nodePtrWeak = ResolveWeakPtr(node);
+
+        SignalBusHandlerFunc handler;
+        handler.mVoidFuncPointer = func;
+
+        if (mEmitting)
+        {
+            mPendingConnects.push_back({ nodePtrWeak, handler });
+        }
+        else
+        {
+            mConnectionMap[nodePtrWeak] = handler;
+        }
+    }
+}
+
+void SignalBusChannel::Connect(Node* node, const ScriptFunc& func)
+{
+    if (node != nullptr)
+    {
+        CleanupDeadConnections();
+        NodePtrWeak nodePtrWeak = ResolveWeakPtr(node);
+
+        SignalBusHandlerFunc handler;
+        handler.mScriptFunc = func;
+
+        if (mEmitting)
+        {
+            mPendingConnects.push_back({ nodePtrWeak, handler });
+        }
+        else
+        {
+            mConnectionMap[nodePtrWeak] = handler;
+        }
+    }
+}
+
+void SignalBusChannel::Disconnect(Node* node)
+{
+    if (node != nullptr)
+    {
+        NodePtrWeak nodePtrWeak = ResolveWeakPtr(node);
+
+        if (mEmitting)
+        {
+            mPendingDisconnects.push_back(nodePtrWeak);
+        }
+        else
+        {
+            mConnectionMap.erase(nodePtrWeak);
+        }
+    }
+}
+
+void SignalBusChannel::Clear()
+{
+    mConnectionMap.clear();
+    mPendingConnects.clear();
+    mPendingDisconnects.clear();
+    mEmitting = false;
+}
+
+void SignalBusChannel::CleanupDeadConnections()
+{
+    if (mEmitting)
+    {
+        return;
+    }
+
+    for (auto it = mConnectionMap.begin(); it != mConnectionMap.end();)
+    {
+        Node* node = it->first.Get<Node>();
+        if (node == nullptr)
+        {
+            it = mConnectionMap.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}
+
+std::vector<Datum> SignalBus::Emit(const std::string& name, const std::vector<Datum>& args)
+{
+    std::vector<Datum> retVals;
+
+    if (mSignalMap.size() > 0)
+    {
+        auto it = mSignalMap.find(name);
+        if (it != mSignalMap.end())
+        {
+            retVals = it->second.Emit(args);
+        }
+    }
+
+    return retVals;
+}
+
+void SignalBus::Subscribe(const std::string& name, Node* listener, SignalBusHandlerFP func)
+{
+    mSignalMap[name].Connect(listener, func);
+}
+
+void SignalBus::Subscribe(const std::string& name, Node* listener, SignalBusHandlerVoidFP func)
+{
+    mSignalMap[name].Connect(listener, func);
+}
+
+void SignalBus::Subscribe(const std::string& name, Node* listener, const ScriptFunc& func)
+{
+    mSignalMap[name].Connect(listener, func);
+}
+
+void SignalBus::Unsubscribe(const std::string& name, Node* listener)
+{
+    auto it = mSignalMap.find(name);
+    if (it != mSignalMap.end())
+    {
+        it->second.Disconnect(listener);
+    }
+}
+
+void SignalBus::Clear()
+{
+    for (auto it = mSignalMap.begin(); it != mSignalMap.end(); ++it)
+    {
+        it->second.Clear();
+    }
+
+    mSignalMap.clear();
+}

--- a/Engine/Source/Engine/SignalBus.h
+++ b/Engine/Source/Engine/SignalBus.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "PolyphaseAPI.h"
+#include "SmartPointer.h"
+#include "ScriptFunc.h"
+#include "Datum.h"
+
+#include <string>
+#include <unordered_map>
+
+class Node;
+
+typedef Datum(*SignalBusHandlerFP)(Node* listener, const std::vector<Datum>& args);
+typedef void(*SignalBusHandlerVoidFP)(Node* listener, const std::vector<Datum>& args);
+
+struct SignalBusHandlerFunc
+{
+    SignalBusHandlerFP mFuncPointer = nullptr;
+    SignalBusHandlerVoidFP mVoidFuncPointer = nullptr;
+    mutable ScriptFunc mScriptFunc;
+};
+
+class SignalBusChannel
+{
+public:
+
+    std::vector<Datum> Emit(const std::vector<Datum>& args);
+    void Connect(Node* node, SignalBusHandlerFP func);
+    void Connect(Node* node, SignalBusHandlerVoidFP func);
+    void Connect(Node* node, const ScriptFunc& func);
+    void Disconnect(Node* node);
+    void Clear();
+
+private:
+
+    void CleanupDeadConnections();
+
+    std::unordered_map<NodePtrWeak, SignalBusHandlerFunc> mConnectionMap;
+    std::vector<std::pair<NodePtrWeak, SignalBusHandlerFunc>> mPendingConnects;
+    std::vector<NodePtrWeak> mPendingDisconnects;
+    bool mEmitting = false;
+};
+
+class POLYPHASE_API SignalBus
+{
+public:
+
+    std::vector<Datum> Emit(const std::string& name, const std::vector<Datum>& args = {});
+    void Subscribe(const std::string& name, Node* listener, SignalBusHandlerFP func);
+    void Subscribe(const std::string& name, Node* listener, SignalBusHandlerVoidFP func);
+    void Subscribe(const std::string& name, Node* listener, const ScriptFunc& func);
+    void Unsubscribe(const std::string& name, Node* listener);
+    void Clear();
+
+private:
+
+    std::unordered_map<std::string, SignalBusChannel> mSignalMap;
+};
+
+POLYPHASE_API SignalBus* GetSignalBus();

--- a/Engine/Source/LuaBindings/LuaBindings.cpp
+++ b/Engine/Source/LuaBindings/LuaBindings.cpp
@@ -88,6 +88,7 @@
 #include "LuaBindings/PolyRect_Lua.h"
 #include "LuaBindings/UIDocument_Lua.h"
 #include "LuaBindings/Signal_Lua.h"
+#include "LuaBindings/SignalBus_Lua.h"
 #include "LuaBindings/Stream_Lua.h"
 #include "LuaBindings/TimerManager_Lua.h"
 #include "LuaBindings/Property_Lua.h"
@@ -121,6 +122,7 @@ void BindLuaInterface()
     AssetManager_Lua::Bind();
     Stream_Lua::Bind();
     Signal_Lua::Bind();
+    SignalBus_Lua::Bind();
     TimerManager_Lua::Bind();
     Easing_Lua::Bind();
     Tween_Lua::Bind();

--- a/Engine/Source/LuaBindings/SignalBus_Lua.cpp
+++ b/Engine/Source/LuaBindings/SignalBus_Lua.cpp
@@ -1,0 +1,82 @@
+#include "LuaBindings/SignalBus_Lua.h"
+
+#include "SignalBus.h"
+
+#include "LuaBindings/LuaUtils.h"
+#include "LuaBindings/Node_Lua.h"
+
+#include "Utilities.h"
+
+#if LUA_ENABLED
+
+int SignalBus_Lua::Subscribe(lua_State* L)
+{
+    const char* signalName = CHECK_STRING(L, 1);
+    Node* listenerNode = CHECK_NODE(L, 2);
+    CHECK_FUNCTION(L, 3);
+
+    ScriptFunc listenerFunc(L, 3);
+    GetSignalBus()->Subscribe(signalName, listenerNode, listenerFunc);
+
+    return 0;
+}
+
+int SignalBus_Lua::Unsubscribe(lua_State* L)
+{
+    const char* signalName = CHECK_STRING(L, 1);
+    Node* listenerNode = CHECK_NODE(L, 2);
+
+    GetSignalBus()->Unsubscribe(signalName, listenerNode);
+
+    return 0;
+}
+
+int SignalBus_Lua::Emit(lua_State* L)
+{
+    const char* signalName = CHECK_STRING(L, 1);
+
+    std::vector<Datum> args;
+    int numArgs = lua_gettop(L) - 1;
+
+    if (numArgs > 0)
+    {
+        args.reserve(numArgs);
+    }
+
+    for (int32_t i = 2; i <= 1 + numArgs; ++i)
+    {
+        args.push_back(LuaObjectToDatum(L, i));
+    }
+
+    std::vector<Datum> retVals = GetSignalBus()->Emit(signalName, args);
+    for (uint32_t i = 0; i < retVals.size(); ++i)
+    {
+        LuaPushDatum(L, retVals[i]);
+    }
+
+    return (int)retVals.size();
+}
+
+int SignalBus_Lua::Clear(lua_State* L)
+{
+    GetSignalBus()->Clear();
+    return 0;
+}
+
+void SignalBus_Lua::Bind()
+{
+    lua_State* L = GetLua();
+
+    lua_newtable(L);
+    int tableIdx = lua_gettop(L);
+
+    REGISTER_TABLE_FUNC(L, tableIdx, Subscribe);
+    REGISTER_TABLE_FUNC(L, tableIdx, Unsubscribe);
+    REGISTER_TABLE_FUNC(L, tableIdx, Emit);
+    REGISTER_TABLE_FUNC(L, tableIdx, Clear);
+
+    lua_setglobal(L, SIGNAL_BUS_LUA_NAME);
+    OCT_ASSERT(lua_gettop(L) == 0);
+}
+
+#endif

--- a/Engine/Source/LuaBindings/SignalBus_Lua.h
+++ b/Engine/Source/LuaBindings/SignalBus_Lua.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "EngineTypes.h"
+
+#if LUA_ENABLED
+
+#define SIGNAL_BUS_LUA_NAME "SignalBus"
+
+struct SignalBus_Lua
+{
+    static int Subscribe(lua_State* L);
+    static int Unsubscribe(lua_State* L);
+    static int Emit(lua_State* L);
+    static int Clear(lua_State* L);
+
+    static void Bind();
+};
+
+#endif


### PR DESCRIPTION
## Summary
Adds a new global `SignalBus` system for cross-scene signaling with both C++ and Lua APIs. The bus supports subscribe/unsubscribe by named channel, emit with arbitrary `Datum` arguments, and collects/returns listener return values.

## Why
Node-local signals are great within a scene tree, but they are awkward for communication that must outlive a specific scene instance or bridge systems across scenes/world transitions. This provides a single global bus that gameplay code and scripts can share.

## What changed
- `Engine/Source/Engine/SignalBus.h/.cpp`
  - Added global `SignalBus` singleton (`GetSignalBus()`)
  - Added named channels with weak-node listener tracking
  - Added C++ subscribe overloads:
    - returning callback (`Datum (*)(Node*, const std::vector<Datum>&)`)
    - void callback (`void (*)(Node*, const std::vector<Datum>&)`)
    - Lua `ScriptFunc`
  - `Emit()` now returns `std::vector<Datum>` with non-empty listener returns
  - Safe connect/disconnect while emitting via pending queues
- `Engine/Source/Engine/Engine.h`
  - Declared global accessor `GetSignalBus()`
- `Engine/Source/Engine/Engine.cpp`
  - Clears SignalBus during shutdown before Lua close to release script refs cleanly
- `Engine/Source/LuaBindings/SignalBus_Lua.h/.cpp`
  - Added global Lua table `SignalBus` with:
    - `SignalBus.Subscribe(name, listenerNode, fn)`
    - `SignalBus.Unsubscribe(name, listenerNode)`
    - `SignalBus.Emit(name, ...)` (returns listener results as Lua return values)
    - `SignalBus.Clear()`
- `Engine/Source/LuaBindings/LuaBindings.cpp`
  - Registers `SignalBus_Lua::Bind()`

## Verification
- `bash /workspace/scripts/verify_compile_linux.sh` ✅
  - Linux Editor build succeeded
  - Editor smoke check succeeded (`PolyphaseEditor.elf -h`)

## Notes for reviewers
- Listener ownership/cleanup mirrors the existing signal behavior by using weak node references.
- `SignalBus.Emit()` currently returns one `Datum` per listener callback when a valid return value exists.